### PR TITLE
up: remove unneeded re-rendering

### DIFF
--- a/src/RPGToolboxContext.tsx
+++ b/src/RPGToolboxContext.tsx
@@ -1,10 +1,10 @@
-import React, { useEffect } from 'react';
-import { createContext, PropsWithChildren, useContext } from 'react';
-import { Widget, WidgetType } from './types/type';
+import React, { useCallback, useEffect } from "react";
+import { createContext, PropsWithChildren, useContext } from "react";
+import { Widget, WidgetType } from "./types/type";
 import {
   loadFromLocalStorage,
   storeItemsInLocalStorage,
-} from './utils/localStorageState';
+} from "./utils/localStorageState";
 
 type RPGToolboxState = {
   chaos: number;
@@ -20,17 +20,17 @@ type RPGToolboxState = {
   instanceId: symbol;
 };
 
-const DASHBOARD_WIDGET_STORAGE_KEY = 'widgets';
+const DASHBOARD_WIDGET_STORAGE_KEY = "widgets";
 const RPGToolBoxContext = createContext<RPGToolboxState | null>(null);
 
 export function RPGToolboxProvider({ children }: PropsWithChildren) {
   const [chaos, setChaos] = React.useState<number>(5);
-  const [fateAnswer, setFateAnswer] = React.useState<string>('-');
+  const [fateAnswer, setFateAnswer] = React.useState<string>("-");
   const [widgets, setWidgets] = React.useState<Widget[]>(
     loadFromLocalStorage(DASHBOARD_WIDGET_STORAGE_KEY) || []
   );
 
-  const instanceId = React.useMemo(() => Symbol('instance-id'), []);
+  const instanceId = React.useMemo(() => Symbol("instance-id"), []);
 
   const addNew = (type: WidgetType) => {
     const newWidget: Widget = {
@@ -40,11 +40,11 @@ export function RPGToolboxProvider({ children }: PropsWithChildren) {
     setWidgets((prev: Widget[]) => [...prev, newWidget]);
   };
 
-  const removeWidget = (id: string) => {
+  const removeWidget = useCallback((id: string) => {
     setWidgets((prev: Widget[]) =>
       prev.filter((widget: Widget) => widget.id !== id)
     );
-  };
+  }, []);
 
   useEffect(() => {
     storeItemsInLocalStorage(widgets, DASHBOARD_WIDGET_STORAGE_KEY);
@@ -72,6 +72,6 @@ export function RPGToolboxProvider({ children }: PropsWithChildren) {
 export function useRPGToolboxContext() {
   const rpgToolboxContext = useContext(RPGToolBoxContext);
   if (!rpgToolboxContext)
-    throw new Error('useRPGToolbox must be used in <RPGToolboxProvider>');
+    throw new Error("useRPGToolbox must be used in <RPGToolboxProvider>");
   return rpgToolboxContext;
 }

--- a/src/features/dashboard/Dashboard.tsx
+++ b/src/features/dashboard/Dashboard.tsx
@@ -1,45 +1,17 @@
 import React, { useEffect, useState } from "react";
-import { OracleWidget } from "../oracle/OracleWidget";
-import { FateQuestionWidget } from "../fate/FateQuestionWidget";
 import { WidgetItem } from "./WidgetItem";
 import { Widget } from "../../types/type";
 import { storeItemsInLocalStorage } from "../../utils/localStorageState";
 import { useRPGToolboxContext } from "../../RPGToolboxContext";
 import { AddNewWidget } from "../addWidget/AddNewWidget";
-import { NpcInteractionWidget } from "../npcConversation/NpcConversationWidget";
-import { ActorWidget } from "../actor/ActorWidget";
 import { Outlet } from "react-router-dom";
-import { Scene } from "../scene/Scene";
-import { ThreadWidget } from "../thread/ThreadWidget";
 import { monitorForElements } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
-import { NameWidget } from "../name/nameWidget";
 
 const DASHBOARD_WIDGET_STORAGE_KEY = "widgets";
 
 const Dashboard: React.FC = () => {
   const { widgets, setWidgets, removeWidget, instanceId } =
     useRPGToolboxContext();
-
-  const renderWidget = (widget: Widget) => {
-    switch (widget.type) {
-      case "oracle":
-        return <OracleWidget widgetId={widget.id} />;
-      case "fate":
-        return <FateQuestionWidget />;
-      case "actor":
-        return <ActorWidget />;
-      case "npcInteraction":
-        return <NpcInteractionWidget />;
-      case "scene":
-        return <Scene />;
-      case "thread":
-        return <ThreadWidget />;
-      case "name":
-        return <NameWidget widgetId={widget.id} />;
-      default:
-        return null;
-    }
-  };
 
   useEffect(
     () => storeItemsInLocalStorage(widgets, DASHBOARD_WIDGET_STORAGE_KEY),
@@ -95,9 +67,8 @@ const Dashboard: React.FC = () => {
                 type={widget.type}
                 removeWidget={removeWidget}
                 src={widget.id}
-              >
-                {renderWidget(widget)}
-              </WidgetItem>
+                instanceId={instanceId}
+              ></WidgetItem>
             ))}
           </div>
           <AddNewWidget />

--- a/src/features/dashboard/WidgetItem.tsx
+++ b/src/features/dashboard/WidgetItem.tsx
@@ -4,17 +4,24 @@ import {
   dropTargetForElements,
 } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
 import { combine } from "@atlaskit/pragmatic-drag-and-drop/combine";
-import Button from "../../components/CustomButton";
 import { css, type SerializedStyles } from "@emotion/react";
-import { useRPGToolboxContext } from "../../RPGToolboxContext";
 import { WidgetHeader } from "./WidgetHeader";
+import { WidgetType } from "../../types/type";
+import { ActorWidget } from "../actor/ActorWidget";
+import { FateQuestionWidget } from "../fate/FateQuestionWidget";
+import { NameWidget } from "../name/nameWidget";
+import { NpcInteractionWidget } from "../npcConversation/NpcConversationWidget";
+import { OracleWidget } from "../oracle/OracleWidget";
+import { Scene } from "../scene/Scene";
+import { ThreadWidget } from "../thread/ThreadWidget";
 
-type WidgetItemProps = PropsWithChildren & {
+type WidgetItemComponentProps = PropsWithChildren & {
   src: string;
   id: string;
-  type: string;
+  type: WidgetType;
   className?: string;
   removeWidget: (id: string) => void;
+  instanceId: symbol;
 };
 
 type State = "idle" | "dragging" | "over";
@@ -35,20 +42,39 @@ const itemStateStyles: { [Key in State]: undefined | SerializedStyles } = {
   }),
 };
 
+const renderWidget = (type: WidgetType, id: string) => {
+  switch (type) {
+    case "oracle":
+      return <OracleWidget widgetId={id} />;
+    case "fate":
+      return <FateQuestionWidget />;
+    case "actor":
+      return <ActorWidget />;
+    case "npcInteraction":
+      return <NpcInteractionWidget />;
+    case "scene":
+      return <Scene />;
+    case "thread":
+      return <ThreadWidget />;
+    case "name":
+      return <NameWidget widgetId={id} />;
+    default:
+      return null;
+  }
+};
+
 // High Order Component: a component that wraps another children component
 // Allows to add additional functionality to a component without modifying its structure
-export const WidgetItem = ({
+const WidgetItemComponent = ({
   src,
-  children,
   id,
   type,
   className = "",
   removeWidget,
-}: WidgetItemProps) => {
+  instanceId,
+}: WidgetItemComponentProps) => {
   const ref = useRef(null);
   const [state, setState] = React.useState<State>("idle");
-
-  const { instanceId } = useRPGToolboxContext();
 
   useEffect(() => {
     const el = ref.current;
@@ -76,6 +102,7 @@ export const WidgetItem = ({
     );
   }, [instanceId, src]);
 
+  console.log(`Rendering ${type}:${id}`); // This would fire on every Dashboard render
   return (
     <div
       ref={ref}
@@ -84,8 +111,10 @@ export const WidgetItem = ({
     >
       <WidgetHeader id={id} type={type} removeWidget={removeWidget} />
       <div className="pt-2 flex-1 flex flex-col bg-gray-50 h-[90%] p-2 space-y-2">
-        {children}
+        {renderWidget(type, id)}
       </div>
     </div>
   );
 };
+
+export const WidgetItem = React.memo(WidgetItemComponent);


### PR DESCRIPTION
Dans cette PR j'essaie d'améliorer les perfs de l'app et faire en sorte que ça ne re-render pas à chaque changement.

Pour ça plusieurs approche:
- Bouger le rendering du widget dans le WidgetItem plutôt que le Dashboard. Comme ça le Dashboard envoie juste le type de widget à crée et c'est le WidgetItem qui se crée lui-même avec le bon sous-composant.
- J'ai rajouté un useCallBack pour removeWidget pour le rendre plus stable et que ça ne déclenche pas non plus un re-render.
- J'ai ajouté un useMemo pour mettre les widget en cache, pour évite des renders additionel si jamais leur props ne sont pas modifié.